### PR TITLE
refactor: Align Maven groupId and base package name to io.github.ceakins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <version>3.3.1</version>
         <relativePath/>
     </parent>
-    <groupId>com.charles.eakins</groupId>
+    <groupId>io.github.ceakins</groupId>
     <artifactId>zello-vault-aggregator</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>Zello Message Vault Aggregator</name>

--- a/src/main/java/io/github/ceakins/zello/ZelloAggregatorApplication.java
+++ b/src/main/java/io/github/ceakins/zello/ZelloAggregatorApplication.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello;
+package io.github.ceakins.zello;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/io/github/ceakins/zello/config/ZelloApiConfig.java
+++ b/src/main/java/io/github/ceakins/zello/config/ZelloApiConfig.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.config;
+package io.github.ceakins.zello.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/io/github/ceakins/zello/controller/SetupController.java
+++ b/src/main/java/io/github/ceakins/zello/controller/SetupController.java
@@ -1,6 +1,6 @@
-package com.charles.eakins.zello.controller;
+package io.github.ceakins.zello.controller;
 
-import com.charles.eakins.zello.ZelloAggregatorApplication;
+import io.github.ceakins.zello.ZelloAggregatorApplication;
 import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/github/ceakins/zello/controller/SetupFilter.java
+++ b/src/main/java/io/github/ceakins/zello/controller/SetupFilter.java
@@ -1,7 +1,7 @@
-package com.charles.eakins.zello.controller;
+package io.github.ceakins.zello.controller;
 
-import com.charles.eakins.zello.ZelloAggregatorApplication;
-import com.charles.eakins.zello.config.ZelloApiConfig;
+import io.github.ceakins.zello.ZelloAggregatorApplication;
+import io.github.ceakins.zello.config.ZelloApiConfig;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/io/github/ceakins/zello/controller/VaultController.java
+++ b/src/main/java/io/github/ceakins/zello/controller/VaultController.java
@@ -1,10 +1,10 @@
-package com.charles.eakins.zello.controller;
+package io.github.ceakins.zello.controller;
 
-import com.charles.eakins.zello.config.ZelloApiConfig;
-import com.charles.eakins.zello.model.HistoryResponse;
-import com.charles.eakins.zello.model.MediaResponse;
-import com.charles.eakins.zello.model.ProcessedMessage;
-import com.charles.eakins.zello.service.ZelloApiService;
+import io.github.ceakins.zello.config.ZelloApiConfig;
+import io.github.ceakins.zello.model.HistoryResponse;
+import io.github.ceakins.zello.model.MediaResponse;
+import io.github.ceakins.zello.model.ProcessedMessage;
+import io.github.ceakins.zello.service.ZelloApiService;
 import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.io.IOException;

--- a/src/main/java/io/github/ceakins/zello/model/HistoryResponse.java
+++ b/src/main/java/io/github/ceakins/zello/model/HistoryResponse.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.model;
+package io.github.ceakins.zello.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/io/github/ceakins/zello/model/LoginResponse.java
+++ b/src/main/java/io/github/ceakins/zello/model/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.model;
+package io.github.ceakins.zello.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/io/github/ceakins/zello/model/MediaResponse.java
+++ b/src/main/java/io/github/ceakins/zello/model/MediaResponse.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.model;
+package io.github.ceakins.zello.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/io/github/ceakins/zello/model/ProcessedMessage.java
+++ b/src/main/java/io/github/ceakins/zello/model/ProcessedMessage.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.model;
+package io.github.ceakins.zello.model;
 
 public class ProcessedMessage {
     private final String displayName;

--- a/src/main/java/io/github/ceakins/zello/model/TokenResponse.java
+++ b/src/main/java/io/github/ceakins/zello/model/TokenResponse.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.model;
+package io.github.ceakins.zello.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/io/github/ceakins/zello/model/UserListResponse.java
+++ b/src/main/java/io/github/ceakins/zello/model/UserListResponse.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.model;
+package io.github.ceakins.zello.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/io/github/ceakins/zello/model/ZelloMessage.java
+++ b/src/main/java/io/github/ceakins/zello/model/ZelloMessage.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.model;
+package io.github.ceakins.zello.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/io/github/ceakins/zello/model/ZelloUser.java
+++ b/src/main/java/io/github/ceakins/zello/model/ZelloUser.java
@@ -1,4 +1,4 @@
-package com.charles.eakins.zello.model;
+package io.github.ceakins.zello.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/io/github/ceakins/zello/service/ZelloApiService.java
+++ b/src/main/java/io/github/ceakins/zello/service/ZelloApiService.java
@@ -1,12 +1,11 @@
-package com.charles.eakins.zello.service;
+package io.github.ceakins.zello.service;
 
-import com.charles.eakins.zello.config.ZelloApiConfig;
-import com.charles.eakins.zello.model.*;
+import io.github.ceakins.zello.config.ZelloApiConfig;
+import io.github.ceakins.zello.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.io.InputStreamResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Service;

--- a/src/test/java/io/github/ceakins/zello/controller/VaultControllerTest.java
+++ b/src/test/java/io/github/ceakins/zello/controller/VaultControllerTest.java
@@ -1,8 +1,8 @@
-package com.charles.eakins.zello.controller;
+package io.github.ceakins.zello.controller;
 
-import com.charles.eakins.zello.config.ZelloApiConfig;
-import com.charles.eakins.zello.model.HistoryResponse;
-import com.charles.eakins.zello.service.ZelloApiService;
+import io.github.ceakins.zello.config.ZelloApiConfig;
+import io.github.ceakins.zello.model.HistoryResponse;
+import io.github.ceakins.zello.service.ZelloApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/src/test/java/io/github/ceakins/zello/service/ZelloApiServiceTest.java
+++ b/src/test/java/io/github/ceakins/zello/service/ZelloApiServiceTest.java
@@ -1,10 +1,10 @@
-package com.charles.eakins.zello.service;
+package io.github.ceakins.zello.service;
 
-import com.charles.eakins.zello.config.ZelloApiConfig;
-import com.charles.eakins.zello.model.LoginResponse;
-import com.charles.eakins.zello.model.TokenResponse;
-import com.charles.eakins.zello.model.UserListResponse;
-import com.charles.eakins.zello.model.ZelloUser;
+import io.github.ceakins.zello.config.ZelloApiConfig;
+import io.github.ceakins.zello.model.LoginResponse;
+import io.github.ceakins.zello.model.TokenResponse;
+import io.github.ceakins.zello.model.UserListResponse;
+import io.github.ceakins.zello.model.ZelloUser;
 // REMOVED: import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;

--- a/testng.xml
+++ b/testng.xml
@@ -2,8 +2,8 @@
 <suite name="ZelloAggregatorSuite" verbose="1">
     <test name="AllTests">
         <classes>
-            <class name="com.charles.eakins.zello.service.ZelloApiServiceTest"/>
-            <class name="com.charles.eakins.zello.controller.VaultControllerTest"/>
+            <class name="io.github.ceakins.zello.service.ZelloApiServiceTest"/>
+            <class name="io.github.ceakins.zello.controller.VaultControllerTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
This commit refactors the project's core identity by updating the Maven groupId and all Java package names to align with modern open-source conventions for projects hosted on GitHub. The new standard coordinate and base package is io.github.ceakins. This is a structural refactoring only and introduces no functional changes to the application. Specific Changes:
pom.xml: The <groupId> has been updated from com.charles.eakins to io.github.ceakins. Java Source Code: All packages under src/main/java and src/test/java have been refactored from com.charles.eakins.* to io.github.ceakins.*. Test Suite (testng.xml): The XML file has been updated to reflect the new fully-qualified class names for all test classes.